### PR TITLE
feat: default enable adjacent seq

### DIFF
--- a/src/commons/Parameters.cpp
+++ b/src/commons/Parameters.cpp
@@ -2515,8 +2515,7 @@ void Parameters::setDefaults() {
     resultDirection = Parameters::PARAM_RESULT_DIRECTION_TARGET;
     weightThr = 0.9;
     weightFile = "";
-    // TODO: change to true after fixing regression tests
-    matchAdjacentSeq = false;
+    matchAdjacentSeq = true;
     hashSeqBuffer = 1.05;
 
     // result2stats


### PR DESCRIPTION
## Description
Enable adjacent sequence matching by default

## Dependencies
This should be merged after the following PRs:
- [ ] https://github.com/soedinglab/MMseqs2/pull/873
- [ ] https://github.com/soedinglab/MMseqs2-Regression/pull/2

